### PR TITLE
Clarifying the full_path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ deploy:
   region: <region>  // Optional, see https://github.com/LearnBoost/knox#region
 
 #also set in your #Directory section:
-  full_path: <full local path>
+  full_path: <full local path> // Full path to the project public directory not including the word "public" at the end
 
 ```
 


### PR DESCRIPTION
I added a note to clarify that the full_path points to the project directory and should not include the
word “project” as part of the path.
