### PR TITLE
Bug fix. S3 client does not sync files without specifying region.

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -31,6 +31,8 @@ module.exports = function(args) {
     help += '    [aws_secret]: <aws_secret>  # Optional, if provided as environment variable\n';
     help += '    [concurrency]: <concurrency>\n';
     help += '    [region]: <region>          # See https://github.com/LearnBoost/knox#region\n\n',
+    help += '#also set in your #Directory section:'
+    help += 'full_path: <full local path>'
     help += 'For more help, you can check the docs: ' + 'https://github.com/nodegarden/hexo-deployer-sync-s3';
 
     console.log(help);
@@ -47,6 +49,7 @@ module.exports = function(args) {
     s3Options: {
       accessKeyId: args.aws_key,
       secretAccessKey: args.aws_secret,
+      region: args.region,
       // any other options are passed to new AWS.S3()
       // See: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#constructor-property
     },


### PR DESCRIPTION
Error like this:

$hexo deploy
INFO  Deploying: s3
INFO  Deploy done: s3
unable to sync: PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.
    at Request.extractError 